### PR TITLE
Fix link typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ The easiest way is to just put the distributed actor and all types required for 
 
 # Contributing
 
-Feel free to fork (see [license](License.md)) or contribute.
+Feel free to fork (see [license](LICENSE)) or contribute.


### PR DESCRIPTION
The license link was pointing to a non-existent file